### PR TITLE
refactor: centralize upload folder

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -8,8 +8,7 @@ from dotenv import load_dotenv
 load_dotenv(override=True)  # .env 파일 로드
 
 # ==============================================================
-# 경로(BASE_DIR, 업로드 폴더)
+# 경로(BASE_DIR)
 # ==============================================================
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-UPLOAD_FOLDER = os.path.join(BASE_DIR, "file", "upload")
 

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -1,3 +1,4 @@
+import os
 from pydantic import AnyUrl, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -11,7 +12,11 @@ class Settings(BaseSettings):
 
     OPENAI_API_KEY: str
     FRIENDLI_API_KEY: str
-    UPLOAD_FOLDER: str = "./file/upload"
+    UPLOAD_FOLDER: str = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "file",
+        "upload",
+    )
     DEBUG: bool = False
     PORT: int = 5000
     DATABASE_URL: AnyUrl | None = None

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from app.api.v1.router import router as v1
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.core.config import UPLOAD_FOLDER
+from app.core.settings import settings
 from fastapi.staticfiles import StaticFiles
 import os
 import uvicorn
@@ -22,7 +22,7 @@ app.add_middleware(
 
 
 if __name__ == "__main__":
-    os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+    os.makedirs(settings.UPLOAD_FOLDER, exist_ok=True)
     uvicorn.run(app, host="0.0.0.0", port=5000)
 
 


### PR DESCRIPTION
## Summary
- remove `UPLOAD_FOLDER` constant from legacy config
- define `UPLOAD_FOLDER` in `Settings` and update `main.py` to use `settings.UPLOAD_FOLDER`

## Testing
- `cd tests/test && PYTHONPATH=../.. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1149d5b748328af7bab009b94ade7