### PR TITLE
refactor: use settings for API keys

### DIFF
--- a/app/api/v1/test.py
+++ b/app/api/v1/test.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Request, UploadFile, File
 from langchain.chains.llm import LLMChain
 from langchain_core.prompts import PromptTemplate
 
-from app.core.config import GOOGLE_API, CLAUDE_API, OPENAI_API
+from app.core.settings import settings
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_community.chat_models import ChatOpenAI
 import anthropic
@@ -19,7 +19,7 @@ async def googletest(request: Request):
     print(body["selected_model"])
 
     # LLM 호출
-    llm = ChatGoogleGenerativeAI(model=body["selected_model"], api_key=GOOGLE_API)
+    llm = ChatGoogleGenerativeAI(model=body["selected_model"], api_key=settings.GOOGLE_API_KEY)
     result = llm.invoke(body["messageInput"])
     print("LLM Result:", result.content)
 
@@ -28,7 +28,7 @@ async def googletest(request: Request):
 # 엔트로픽 모델 리스트 가져오기
 @router.post("/getModelList")
 async def getModelList(request: Request):
-    client = anthropic.Anthropic(api_key=CLAUDE_API)
+    client = anthropic.Anthropic(api_key=settings.ANTHROPIC_API_KEY)
     result = client.models.list(limit=20)
     print(result)
     return{"response": "엔트로픽 모델리스트 테스트", "models":result}
@@ -36,7 +36,7 @@ async def getModelList(request: Request):
 # 오픈ai 모델 리스트 가져오기
 @router.post("/getModelList2")
 async def getModelList2(request: Request):
-    client2 = OpenAI(api_key=OPENAI_API)
+    client2 = OpenAI(api_key=settings.OPENAI_API_KEY)
     result = client2.models.list()
     print(result)
     return{"response": "OPENAI 모델", "models":result}
@@ -49,7 +49,7 @@ async def userInputPrompt(request: Request):
         model_name="gpt-3.5-turbo",
         temperature=0,
         streaming=False,
-        openai_api_key=OPENAI_API
+        openai_api_key=settings.OPENAI_API_KEY
     )
 
     template = """

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -1,5 +1,5 @@
 import os
-from pydantic import AnyUrl, Field
+from pydantic import AnyUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
@@ -10,8 +10,10 @@ class Settings(BaseSettings):
         extra="ignore",            # 정의되지 않은 키 무시
     )
 
-    OPENAI_API_KEY: str
-    FRIENDLI_API_KEY: str
+    OPENAI_API_KEY: str | None = None
+    ANTHROPIC_API_KEY: str | None = None
+    GOOGLE_API_KEY: str | None = None
+    FRIENDLI_API_KEY: str | None = None
     UPLOAD_FOLDER: str = os.path.join(
         os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
         "file",


### PR DESCRIPTION
## Summary
- access API keys via settings instead of config constants
- add missing GOOGLE and ANTHROPIC API key fields

## Testing
- `PYTHONPATH=. pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '../../test.pdf')*

------
https://chatgpt.com/codex/tasks/task_e_68b12f821ea8832892c7e142acc863f2