### PR TITLE
Wrap Upstage analyzer request errors

### DIFF
--- a/app/api/v1/ingestion.py
+++ b/app/api/v1/ingestion.py
@@ -69,7 +69,10 @@ def analyze_endpoint(req: AnalyzeRequest):
         p = Path(pdf_path)
         if not p.exists():
             raise HTTPException(status_code=404, detail=f"없음: {pdf_path}")
-        json_path = analyzer.execute(str(p))
+        try:
+            json_path = analyzer.execute(str(p))
+        except ValueError as e:
+            raise HTTPException(status_code=502, detail=str(e))
         out[str(p.resolve())] = str(Path(json_path).resolve())
     return AnalyzeResponse(json_paths=out)
 
@@ -104,7 +107,10 @@ def run_endpoint(req: RunRequest):
     analyzer = LayoutAnalyzer(api_key)
     json_paths: Dict[str, str] = {}
     for part in parts:
-        json_path = analyzer.execute(part)
+        try:
+            json_path = analyzer.execute(part)
+        except ValueError as e:
+            raise HTTPException(status_code=502, detail=str(e))
         json_paths[str(Path(part).resolve())] = str(Path(json_path).resolve())
     # 3) extract + render
     ## proc <- PDF 처리기(Processor) 인스턴스 의 변수

--- a/app/services/ingestion/preprocess/analyzer_upstage.py
+++ b/app/services/ingestion/preprocess/analyzer_upstage.py
@@ -26,13 +26,16 @@ class LayoutAnalyzer:
         data = {"ocr": "false"}  # 필요 시 "true" 로 변경
 
         with input_path.open("rb") as f:
-            response = requests.post(
-                url,
-                headers=headers,
-                data=data,
-                files={"document": f},
-                timeout=120,
-            )
+            try:
+                response = requests.post(
+                    url,
+                    headers=headers,
+                    data=data,
+                    files={"document": f},
+                    timeout=120,
+                )
+            except requests.RequestException as e:
+                raise ValueError(f"Upstage layout API 요청 실패: {e}") from e
 
         if response.status_code != 200:
             snippet = (response.text or "")[:200]


### PR DESCRIPTION
## Summary
- handle Upstage Layout API request failures and propagate as ValueError
- translate analyzer errors to 502 responses in ingestion endpoints

## Testing
- `PYTHONPATH=../.. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b12fa8dc848328bc0e93054ff715a5