### PR TITLE
feat: add database models and migrations

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///./app.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+import os
+import sys
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from app.core.settings import settings  # noqa: E402
+from app.db.base import Base  # noqa: E402
+import app.db.models  # noqa: F401,E402  # Ensure models are imported
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+config.set_main_option("sqlalchemy.url", settings.DATABASE_URL or "sqlite:///./app.db")
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/0001_create_initial_tables.py
+++ b/alembic/versions/0001_create_initial_tables.py
@@ -1,0 +1,76 @@
+"""create initial tables"""
+
+from alembic import op
+import sqlalchemy as sa
+from pgvector.sqlalchemy import Vector
+
+revision = "0001_create_initial_tables"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        "file",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("original_name", sa.String(length=255), nullable=False),
+        sa.Column("mime_type", sa.String(length=50)),
+        sa.Column("storage_path", sa.String(length=512), nullable=False),
+        sa.Column(
+            "uploaded_at", sa.DateTime(), nullable=False, server_default=sa.func.now()
+        ),
+    )
+    op.create_table(
+        "document",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "file_id", sa.BigInteger(), sa.ForeignKey("file.id", ondelete="CASCADE")
+        ),
+        sa.Column("title", sa.String(length=255)),
+        sa.Column("doc_meta", sa.JSON()),
+        sa.Column(
+            "created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()
+        ),
+    )
+    op.create_table(
+        "chunk",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "document_id",
+            sa.BigInteger(),
+            sa.ForeignKey("document.id", ondelete="CASCADE"),
+        ),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("chunk_order", sa.Integer()),
+        sa.Column("chunk_meta", sa.JSON()),
+        sa.UniqueConstraint("document_id", "chunk_order", name="uq_chunk_document_order"),
+    )
+    op.create_table(
+        "embedding",
+        sa.Column(
+            "chunk_id",
+            sa.BigInteger(),
+            sa.ForeignKey("chunk.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column("vector", Vector(1536)),
+        sa.Column("model", sa.String(length=100)),
+        sa.Column("dim", sa.Integer()),
+    )
+    op.create_table(
+        "chat_history",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("user_input", sa.Text(), nullable=False),
+        sa.Column("llm_output", sa.Text()),
+        sa.Column(
+            "created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("chat_history")
+    op.drop_table("embedding")
+    op.drop_table("chunk")
+    op.drop_table("document")
+    op.drop_table("file")

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,0 +1,3 @@
+from .base import Base
+
+__all__ = ["Base"]

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import (
+    BigInteger,
+    DateTime,
+    ForeignKey,
+    Integer,
+    JSON,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from pgvector.sqlalchemy import Vector
+
+from .base import Base
+
+
+class File(Base):
+    __tablename__ = "file"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    original_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    mime_type: Mapped[str | None] = mapped_column(String(50))
+    storage_path: Mapped[str] = mapped_column(String(512), nullable=False)
+    uploaded_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )
+
+    documents: Mapped[list[Document]] = relationship(
+        back_populates="file", cascade="all, delete-orphan"
+    )
+
+
+class Document(Base):
+    __tablename__ = "document"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    file_id: Mapped[int | None] = mapped_column(
+        ForeignKey("file.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    title: Mapped[str | None] = mapped_column(String(255))
+    doc_meta: Mapped[dict | None] = mapped_column(JSON)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )
+
+    file: Mapped[File | None] = relationship(back_populates="documents")
+    chunks: Mapped[list[Chunk]] = relationship(
+        back_populates="document", cascade="all, delete-orphan"
+    )
+
+
+class Chunk(Base):
+    __tablename__ = "chunk"
+    __table_args__ = (
+        UniqueConstraint("document_id", "chunk_order", name="uq_chunk_document_order"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    document_id: Mapped[int | None] = mapped_column(
+        ForeignKey("document.id", ondelete="CASCADE"), nullable=True
+    )
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    chunk_order: Mapped[int | None] = mapped_column(Integer)
+    chunk_meta: Mapped[dict | None] = mapped_column(JSON)
+
+    document: Mapped[Document | None] = relationship(back_populates="chunks")
+    embedding: Mapped[Embedding | None] = relationship(
+        back_populates="chunk", cascade="all, delete-orphan"
+    )
+
+
+class Embedding(Base):
+    __tablename__ = "embedding"
+
+    chunk_id: Mapped[int] = mapped_column(
+        ForeignKey("chunk.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    vector: Mapped[list[float] | None] = mapped_column(Vector(1536))
+    model: Mapped[str | None] = mapped_column(String(100))
+    dim: Mapped[int | None] = mapped_column(Integer)
+
+    chunk: Mapped[Chunk | None] = relationship(back_populates="embedding")
+
+
+class ChatHistory(Base):
+    __tablename__ = "chat_history"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    user_input: Mapped[str] = mapped_column(Text, nullable=False)
+    llm_output: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.settings import settings
+
+DATABASE_URL = settings.DATABASE_URL or "sqlite:///./app.db"
+
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- define SQLAlchemy models for File, Document, Chunk, Embedding, ChatHistory
- add database session helper
- configure Alembic and create initial migration

## Testing
- `alembic upgrade head`
- `cd tests/test && PYTHONPATH=../.. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75d833e988328b30b3ae542e4c0db