### PR TITLE
feat: add database models

### DIFF
--- a/app/api/v1/chat.py
+++ b/app/api/v1/chat.py
@@ -1,5 +1,0 @@
-# 대화 세션 관리
-from fastapi import APIRouter
-
-router = APIRouter(prefix="/chat", tags=["chat"])
-

--- a/app/api/v1/chat_history.py
+++ b/app/api/v1/chat_history.py
@@ -1,0 +1,19 @@
+"""대화 히스토리 엔드포인트"""
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.db import crud
+from app.schemas.db import ChatHistoryCreate, ChatHistoryRead
+
+router = APIRouter(prefix="/chat", tags=["chat"])
+
+
+@router.post("/history", response_model=ChatHistoryRead)
+def create_history(log: ChatHistoryCreate, db: Session = Depends(get_db)):
+    return crud.create_chathistory(db, log)
+
+
+@router.get("/history", response_model=list[ChatHistoryRead])
+def list_history(db: Session = Depends(get_db)):
+    return crud.list_chathistory(db)

--- a/app/api/v1/documents.py
+++ b/app/api/v1/documents.py
@@ -1,0 +1,50 @@
+"""문서 및 청크 CRUD 엔드포인트"""
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.db import crud
+from app.schemas.db import (
+    DocumentCreate,
+    DocumentRead,
+    ChunkCreate,
+    ChunkRead,
+)
+
+router = APIRouter(prefix="/documents", tags=["documents"])
+
+
+@router.post("/", response_model=DocumentRead)
+def create_document(document: DocumentCreate, db: Session = Depends(get_db)):
+    if not crud.get_file(db, document.file_id):
+        raise HTTPException(status_code=404, detail="파일을 찾을 수 없습니다")
+    return crud.create_document(db, document)
+
+
+@router.get("/{doc_id}", response_model=DocumentRead)
+def get_document(doc_id: int, db: Session = Depends(get_db)):
+    doc = crud.get_document(db, doc_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다")
+    return doc
+
+
+@router.get("/", response_model=list[DocumentRead])
+def list_documents(db: Session = Depends(get_db)):
+    return crud.list_documents(db)
+
+
+@router.post("/{doc_id}/chunks", response_model=ChunkRead)
+def add_chunk(doc_id: int, chunk: ChunkCreate, db: Session = Depends(get_db)):
+    if doc_id != chunk.document_id:
+        raise HTTPException(status_code=400, detail="문서 ID 불일치")
+    if not crud.get_document(db, doc_id):
+        raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다")
+    return crud.create_chunk(db, chunk)
+
+
+@router.get("/{doc_id}/chunks", response_model=list[ChunkRead])
+def list_chunks(doc_id: int, db: Session = Depends(get_db)):
+    if not crud.get_document(db, doc_id):
+        raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다")
+    return crud.list_chunks_by_document(db, doc_id)

--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -1,5 +1,27 @@
-# Upload / Ingest trigger
-# app/api/v1/auth.py
-from fastapi import APIRouter
+"""파일 관련 CRUD 엔드포인트"""
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.db import crud
+from app.schemas.db import FileCreate, FileRead
 
 router = APIRouter(prefix="/files", tags=["files"])
+
+
+@router.post("/", response_model=FileRead)
+def create_file(file: FileCreate, db: Session = Depends(get_db)):
+    return crud.create_file(db, file)
+
+
+@router.get("/{file_id}", response_model=FileRead)
+def get_file(file_id: int, db: Session = Depends(get_db)):
+    db_file = crud.get_file(db, file_id)
+    if not db_file:
+        raise HTTPException(status_code=404, detail="파일을 찾을 수 없습니다")
+    return db_file
+
+
+@router.get("/", response_model=list[FileRead])
+def list_files(db: Session = Depends(get_db)):
+    return crud.list_files(db)

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -1,14 +1,6 @@
 from fastapi import APIRouter
-from . import auth, files, rag, chat, admin, test,ingestion
-# from ...services import ingestion
+from . import auth, files, rag, chat_history, admin, test, ingestion, documents
 
-# router = APIRouter(prefix="/v1")
 router = APIRouter()
-for r in (auth, files, rag, chat, admin,test,ingestion):
+for r in (auth, files, rag, chat_history, admin, test, ingestion, documents):
     router.include_router(r.router)
-
-# router = APIRouter(prefix="/v1")
-# router.include_router(test.test_router)
-
-# from app.api.v1.ingestion import router as ingestion
-# router.include_router(ingestion, prefix="/api/v1")

--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -1,0 +1,78 @@
+from sqlalchemy.orm import Session
+from . import models
+from app.schemas.db import (
+    FileCreate,
+    DocumentCreate,
+    ChunkCreate,
+    EmbeddingCreate,
+    ChatHistoryCreate,
+)
+
+
+def create_file(db: Session, file_in: FileCreate) -> models.File:
+    db_obj = models.File(**file_in.model_dump())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def get_file(db: Session, file_id: int) -> models.File | None:
+    return db.query(models.File).filter(models.File.id == file_id).first()
+
+
+def list_files(db: Session) -> list[models.File]:
+    return db.query(models.File).all()
+
+
+def create_document(db: Session, doc_in: DocumentCreate) -> models.Document:
+    db_obj = models.Document(**doc_in.model_dump())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def get_document(db: Session, doc_id: int) -> models.Document | None:
+    return db.query(models.Document).filter(models.Document.id == doc_id).first()
+
+
+def list_documents(db: Session) -> list[models.Document]:
+    return db.query(models.Document).all()
+
+
+def create_chunk(db: Session, chunk_in: ChunkCreate) -> models.Chunk:
+    db_obj = models.Chunk(**chunk_in.model_dump())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def list_chunks_by_document(db: Session, document_id: int) -> list[models.Chunk]:
+    return (
+        db.query(models.Chunk)
+        .filter(models.Chunk.document_id == document_id)
+        .order_by(models.Chunk.chunk_order)
+        .all()
+    )
+
+
+def create_embedding(db: Session, emb_in: EmbeddingCreate) -> models.Embedding:
+    db_obj = models.Embedding(**emb_in.model_dump())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def create_chathistory(db: Session, log_in: ChatHistoryCreate) -> models.ChatHistory:
+    db_obj = models.ChatHistory(**log_in.model_dump())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def list_chathistory(db: Session) -> list[models.ChatHistory]:
+    return db.query(models.ChatHistory).order_by(models.ChatHistory.created_at.desc()).all()

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,0 +1,65 @@
+from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+from pgvector.sqlalchemy import Vector
+
+from .base import Base
+
+
+class File(Base):
+    __tablename__ = "files"
+
+    id = Column(BigInteger, primary_key=True, index=True)
+    original_name = Column(String, nullable=False)
+    mime_type = Column(String, nullable=False)
+    storage_path = Column(String, nullable=False)
+    uploaded_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    documents = relationship("Document", back_populates="file")
+
+
+class Document(Base):
+    __tablename__ = "documents"
+
+    id = Column(BigInteger, primary_key=True, index=True)
+    file_id = Column(BigInteger, ForeignKey("files.id", ondelete="CASCADE"), nullable=False)
+    title = Column(String, nullable=False)
+    doc_meta = Column(JSONB, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    file = relationship("File", back_populates="documents")
+    chunks = relationship("Chunk", back_populates="document")
+
+
+class Chunk(Base):
+    __tablename__ = "chunks"
+
+    id = Column(BigInteger, primary_key=True, index=True)
+    document_id = Column(BigInteger, ForeignKey("documents.id", ondelete="CASCADE"), nullable=False)
+    content = Column(Text, nullable=False)
+    chunk_order = Column(Integer, nullable=False)
+    chunk_meta = Column(JSONB, nullable=True)
+
+    document = relationship("Document", back_populates="chunks")
+    embedding = relationship("Embedding", uselist=False, back_populates="chunk")
+
+
+class Embedding(Base):
+    __tablename__ = "embeddings"
+
+    chunk_id = Column(BigInteger, ForeignKey("chunks.id", ondelete="CASCADE"), primary_key=True)
+    vector = Column(Vector(), nullable=False)
+    model = Column(String, nullable=False)
+    dim = Column(Integer, nullable=False)
+
+    chunk = relationship("Chunk", back_populates="embedding")
+
+
+class ChatHistory(Base):
+    __tablename__ = "chat_history"
+
+    id = Column(BigInteger, primary_key=True, index=True)
+    user_input = Column(Text, nullable=False)
+    llm_output = Column(Text, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,0 +1,14 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from app.core.settings import settings
+
+engine = create_engine(str(settings.DATABASE_URL), future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/schemas/db.py
+++ b/app/schemas/db.py
@@ -1,0 +1,90 @@
+from datetime import datetime
+from typing import Any, List, Optional
+from pydantic import BaseModel
+
+
+class FileBase(BaseModel):
+    original_name: str
+    mime_type: str
+    storage_path: str
+
+
+class FileCreate(FileBase):
+    pass
+
+
+class FileRead(FileBase):
+    id: int
+    uploaded_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class DocumentBase(BaseModel):
+    file_id: int
+    title: str
+    doc_meta: Optional[dict[str, Any]] = None
+
+
+class DocumentCreate(DocumentBase):
+    pass
+
+
+class DocumentRead(DocumentBase):
+    id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class ChunkBase(BaseModel):
+    document_id: int
+    content: str
+    chunk_order: int
+    chunk_meta: Optional[dict[str, Any]] = None
+
+
+class ChunkCreate(ChunkBase):
+    pass
+
+
+class ChunkRead(ChunkBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class EmbeddingBase(BaseModel):
+    chunk_id: int
+    vector: List[float]
+    model: str
+    dim: int
+
+
+class EmbeddingCreate(EmbeddingBase):
+    pass
+
+
+class EmbeddingRead(EmbeddingBase):
+    class Config:
+        orm_mode = True
+
+
+class ChatHistoryBase(BaseModel):
+    user_input: str
+    llm_output: str
+
+
+class ChatHistoryCreate(ChatHistoryBase):
+    pass
+
+
+class ChatHistoryRead(ChatHistoryBase):
+    id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/tests/test/test_analyzer_upstage.py
+++ b/tests/test/test_analyzer_upstage.py
@@ -13,7 +13,7 @@ def test_analyzer_mock(monkeypatch, tmp_path: Path):
     import requests
     monkeypatch.setattr(requests, "post", fake_post)
 
-    src = Path("../../test.pdf")  # 실제 파일 존재 필요 없음. open은 analyzer 내부에서 requests만 사용.
+    src = Path(__file__).resolve().parents[2] / "test.pdf"  # 실제 파일 존재 필요 없음. open은 analyzer 내부에서 requests만 사용.
     # monkeypatch로 파일 open 경로를 대체하려면 더 감쌀 수 있지만 여기선 post만 목킹
     out = LayoutAnalyzer(api_key="x").analyze(src)
     assert Path(out).suffix == ".json"

--- a/tests/test/test_split_pdf.py
+++ b/tests/test/test_split_pdf.py
@@ -3,7 +3,7 @@ from app.services.ingestion.preprocess.split_pdf import split_pdf
 
 def test_split_pdf(tmp_path: Path):
     # 준비: 샘플 PDF 복사
-    src = Path("../../test.pdf")
+    src = Path(__file__).resolve().parents[2] / "test.pdf"
     out = tmp_path
     parts = split_pdf(src, out_dir=out, batch_size=5)
     assert len(parts) >= 1


### PR DESCRIPTION
## Summary
- define core database models including chat history
- provide CRUD utilities and FastAPI endpoints
- support PostgreSQL/pgvector via SQLAlchemy session with .env configuration
- rename chat log resources to chat history

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7763408288328ba57da6368ba1c36