### PR TITLE
feat: add QA chain and fix OpenAI key handling

### DIFF
--- a/app/langchain/chains/qa_chain.py
+++ b/app/langchain/chains/qa_chain.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any
+
+from dotenv import load_dotenv, find_dotenv
+from langchain_core.prompts import PromptTemplate
+from langchain_core.runnables import RunnablePassthrough
+from langchain_core.output_parsers import StrOutputParser
+from langchain_openai import ChatOpenAI
+
+load_dotenv(find_dotenv())
+
+def build_qa_chain(vectorstore: Any):
+    """벡터스토어 기반 QA 체인을 생성한다.
+
+    Args:
+        vectorstore: ``as_retriever`` 메서드를 제공하는 벡터스토어 인스턴스.
+
+    Returns:
+        LangChain Runnable. ``invoke({"question": "..."})`` 형식으로 호출한다.
+    """
+    retriever = vectorstore.as_retriever()
+
+    prompt = PromptTemplate.from_template(
+        """당신은 질문과 답변을 도와주는 어시스턴트입니다.
+#Context:
+{context}
+
+#Question:
+{question}
+
+#Answer:"""
+    )
+
+    llm = ChatOpenAI(model_name="gpt-3.5-turbo", temperature=0)
+
+    chain = (
+        {"context": retriever, "question": RunnablePassthrough()}
+        | prompt
+        | llm
+        | StrOutputParser()
+    )
+    return chain

--- a/app/services/ingestion/embedding.py
+++ b/app/services/ingestion/embedding.py
@@ -20,7 +20,7 @@ def embed_text(text: str, model: str = "text-embedding-3-small") -> Tuple[List[f
     Returns:
         (생성된 벡터, 모델명, 벡터 차원)의 튜플.
     """
-    api_key = os.getenv("OPENAI_API")
+    api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise ValueError("OPENAI_API_KEY 환경 변수가 설정되어 있지 않습니다")
 


### PR DESCRIPTION
## Summary
- build retrieval-augmented QA chain using LangChain
- read OpenAI API key from `OPENAI_API_KEY`

## Testing
- `pytest` *(fails: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68bfd56688a88328b9ffebb0c1c06a64