### PR TITLE
feat: enable pgvector retrieval in RAG

### DIFF
--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -78,3 +78,16 @@ def create_chathistory(db: Session, log_in: ChatHistoryCreate) -> models.ChatHis
 
 def list_chathistory(db: Session) -> list[models.ChatHistory]:
     return db.query(models.ChatHistory).order_by(models.ChatHistory.created_at.desc()).all()
+
+
+def search_chunks_by_vector(
+    db: Session, query_vector: list[float], limit: int = 4
+) -> list[models.Chunk]:
+    """임베딩 벡터와 유사한 청크를 반환한다."""
+    return (
+        db.query(models.Chunk)
+        .join(models.Embedding)
+        .order_by(models.Embedding.vector.cosine_distance(query_vector))
+        .limit(limit)
+        .all()
+    )

--- a/app/services/ingestion/vectorstore.py
+++ b/app/services/ingestion/vectorstore.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+"""문서를 파싱하고 임베딩하여 벡터스토어에 저장/로드하는 유틸리티."""
+
+import json
+import os
+from pathlib import Path
+from typing import List, Dict
+
+from langchain_community.vectorstores import FAISS
+from langchain_openai import OpenAIEmbeddings
+
+from .parser import parse_to_md_html
+from .chunking import chunk_text
+from .embedding import embed_text
+
+# 벡터스토어 기본 경로 (환경 변수로 재정의 가능)
+DEFAULT_VECTORSTORE_PATH = Path(os.getenv("VECTORSTORE_PATH", "file/vectorstore/faiss")).resolve()
+
+
+def ingest_pdf_to_faiss(pdf_path: str, vs_path: Path | None = None) -> str:
+    """PDF를 파싱하여 FAISS 벡터스토어로 저장한다.
+
+    Args:
+        pdf_path: 원본 PDF 경로.
+        vs_path: 저장할 벡터스토어 경로. 주어지지 않으면 환경 변수를 사용한다.
+
+    Returns:
+        저장된 벡터스토어 경로 문자열.
+    """
+    vs_path = Path(vs_path or DEFAULT_VECTORSTORE_PATH).resolve()
+
+    parse_out = parse_to_md_html(pdf_path)
+    md_path = Path(parse_out["md_path"])
+    with md_path.open("r", encoding="utf-8") as f:
+        md_text = f.read()
+
+    chunks = chunk_text(md_text)
+    texts: List[str] = []
+    vectors: List[List[float]] = []
+    metadatas: List[Dict[str, str]] = []
+    model_name = None
+    for chunk in chunks:
+        vec, model_name, _ = embed_text(chunk["text"])
+        texts.append(chunk["text"])
+        vectors.append(vec)
+        metadatas.append({"source": pdf_path, "order": str(chunk["order"])})
+
+    embedding_fn = OpenAIEmbeddings(model=model_name)
+    vs = FAISS.from_embeddings(list(zip(texts, vectors)), embedding_fn, metadatas=metadatas)
+    vs_path.parent.mkdir(parents=True, exist_ok=True)
+    vs.save_local(str(vs_path))
+    with (vs_path / "meta.json").open("w", encoding="utf-8") as f:
+        json.dump({"model": model_name}, f)
+    return str(vs_path)
+
+
+def load_faiss_vectorstore(vs_path: Path | None = None) -> FAISS:
+    """저장된 FAISS 벡터스토어를 로드한다."""
+    vs_path = Path(vs_path or DEFAULT_VECTORSTORE_PATH).resolve()
+    meta_path = vs_path / "meta.json"
+    if not meta_path.exists():
+        raise FileNotFoundError(f"메타데이터 파일이 존재하지 않습니다: {meta_path}")
+    with meta_path.open("r", encoding="utf-8") as f:
+        model_name = json.load(f).get("model", "text-embedding-3-small")
+    embedding_fn = OpenAIEmbeddings(model=model_name)
+    return FAISS.load_local(str(vs_path), embedding_fn, allow_dangerous_deserialization=True)

--- a/app/services/rag/pgvector_store.py
+++ b/app/services/rag/pgvector_store.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from langchain_core.documents import Document
+from langchain_core.embeddings import Embeddings
+from langchain_core.retrievers import BaseRetriever
+from pydantic import ConfigDict
+
+from app.db import crud
+from app.db.session import SessionLocal
+
+
+class PGVectorRetriever(BaseRetriever):
+    """pgvector에 저장된 임베딩을 조회하는 간단한 Retriever."""
+
+    embeddings: Embeddings
+    k: int = 4
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    def _get_relevant_documents(self, query: str, *, run_manager) -> list[Document]:
+        query_vector = self.embeddings.embed_query(query)
+        with SessionLocal() as db:
+            chunks = crud.search_chunks_by_vector(db, query_vector, limit=self.k)
+        return [Document(page_content=c.content, metadata={"chunk_id": c.id}) for c in chunks]
+
+    async def _aget_relevant_documents(self, query: str, *, run_manager) -> list[Document]:
+        return self._get_relevant_documents(query, run_manager=run_manager)
+
+
+class PGVectorStore:
+    """`build_qa_chain`에 전달하기 위한 최소한의 인터페이스."""
+
+    def __init__(self, embeddings: Embeddings):
+        self.embeddings = embeddings
+
+    def as_retriever(self, search_kwargs: Optional[dict] = None) -> PGVectorRetriever:
+        k = search_kwargs.get("k", 4) if search_kwargs else 4
+        return PGVectorRetriever(embeddings=self.embeddings, k=k)

--- a/app/services/rag/service.py
+++ b/app/services/rag/service.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 from typing import Optional
 
 from dotenv import load_dotenv
-from langchain_core.documents import Document
 from langchain_core.language_models import BaseLanguageModel
-from langchain_core.vectorstores import InMemoryVectorStore, VectorStore
+from langchain_core.vectorstores import VectorStore
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+
 from app.langchain.chains.qa_chain import build_qa_chain
+from app.services.rag.pgvector_store import PGVectorStore
 
 
 class RAGService:
     """질의 응답을 수행하는 간단한 RAG 서비스."""
+
     def __init__(self, vectorstore: VectorStore, llm: BaseLanguageModel):
         self.chain = build_qa_chain(vectorstore, llm)
 
@@ -21,12 +23,11 @@ class RAGService:
 
 
 def _build_default_service() -> RAGService:
-    """기본 InMemoryVectorStore와 OpenAI 기반 LLM로 구성된 RAGService 생성."""
+    """PostgreSQL에 저장된 임베딩을 기반으로 RAGService를 생성한다."""
 
     load_dotenv()
-    embedding = OpenAIEmbeddings()
-    vectorstore = InMemoryVectorStore(embedding=embedding)
-    vectorstore.add_documents([Document(page_content="고양이는 귀엽다.")])
+    embeddings = OpenAIEmbeddings(model="text-embedding-3-large")
+    vectorstore = PGVectorStore(embeddings)
     llm = ChatOpenAI(model_name="gpt-4o", temperature=0)
     return RAGService(vectorstore, llm)
 
@@ -40,4 +41,3 @@ def get_rag_service() -> RAGService:
     if _default_service is None:
         _default_service = _build_default_service()
     return _default_service
-


### PR DESCRIPTION
## Summary
- add pgvector-backed retriever and store wrapper for LangChain
- query Postgres embeddings in RAG service via custom retriever
- expose vector search helper in database CRUD module

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c10553c2f88328ae39e1ae41514a54