### PR TITLE
feat: replace faiss with pgvector

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
  
 - FastAPI
 - LangChain/LangGraph
-- PostgreSQL/pgvector
+- PostgreSQL/pgvector (FAISS 미사용)
 
 문서 인제스트 → 하이브리드 검색(BM25+벡터) → LLM 생성 응답까지 하나의 백엔드로 제공
 

--- a/app/services/rag/vectorstore.py
+++ b/app/services/rag/vectorstore.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Callable, List, Optional, Tuple
+
+from langchain_core.documents import Document
+from langchain_core.retrievers import BaseRetriever
+from sqlalchemy.orm import Session
+
+from app.db import crud
+
+
+class PGVectorRetriever(BaseRetriever):
+    def __init__(self, db: Session, embed_fn: Callable[[str], Tuple[List[float], str]], k: int):
+        self.db = db
+        self.embed_fn = embed_fn
+        self.k = k
+
+    def _get_relevant_documents(self, query: str, run_manager=None) -> List[Document]:
+        vector, _ = self.embed_fn(query)
+        results = crud.search_chunks_by_vector(self.db, vector, self.k)
+        return [
+            Document(
+                page_content=chunk.content,
+                metadata={
+                    "score": score,
+                    "chunk_id": chunk.id,
+                    "document_id": chunk.document_id,
+                },
+            )
+            for chunk, score in results
+        ]
+
+    async def _aget_relevant_documents(self, query: str, run_manager=None) -> List[Document]:
+        return self._get_relevant_documents(query, run_manager)
+
+
+class PGVectorStore:
+    def __init__(self, db: Session, embed_fn: Callable[[str], Tuple[List[float], str]]):
+        self.db = db
+        self.embed_fn = embed_fn
+
+    def as_retriever(self, search_kwargs: Optional[dict] = None) -> PGVectorRetriever:
+        k = 4
+        if search_kwargs and "k" in search_kwargs:
+            k = search_kwargs["k"]
+        return PGVectorRetriever(self.db, self.embed_fn, k)


### PR DESCRIPTION
## Summary
- use pgvector-backed search via `search_chunks_by_vector`
- add `PGVectorStore` and wire rag service to it
- clarify in docs that FAISS is no longer used

## Testing
- `python -m py_compile app/db/crud.py app/services/rag/*.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1099befb88328b65a77bda231852b