### PR TITLE
Add vector search helper for RAG

### DIFF
--- a/app/services/rag/service.py
+++ b/app/services/rag/service.py
@@ -16,11 +16,16 @@ class RAGService:
     """질의 응답을 수행하는 간단한 RAG 서비스."""
 
     def __init__(self, vectorstore: PGVectorStore, llm: BaseLanguageModel):
+        self.vectorstore = vectorstore
         self.chain = build_qa_chain(vectorstore, llm)
 
     def query(self, question: str) -> str:
         """질문을 받아 답변 문자열을 반환한다."""
         return self.chain.invoke(question)
+
+    def get_relevant_chunks(self, question: str, k: int = 4):
+        """질문과 가장 유사한 청크 목록을 반환한다."""
+        return self.vectorstore.search(question, k)
 
 
 def _build_default_service() -> RAGService:

--- a/app/services/rag/vectorstore.py
+++ b/app/services/rag/vectorstore.py
@@ -45,3 +45,19 @@ class PGVectorStore:
         if search_kwargs and "k" in search_kwargs:
             k = search_kwargs["k"]
         return PGVectorRetriever(db=self.db, embed_fn=self.embed_fn, k=k)
+
+    def search(self, query: str, k: int = 4) -> List[Document]:
+        """주어진 질의와 가장 유사한 청크들을 반환한다."""
+        vector, _ = self.embed_fn(query)
+        results = crud.search_chunks_by_vector(self.db, vector, k)
+        return [
+            Document(
+                page_content=chunk.content,
+                metadata={
+                    "score": score,
+                    "chunk_id": chunk.id,
+                    "document_id": chunk.document_id,
+                },
+            )
+            for chunk, score in results
+        ]


### PR DESCRIPTION
## Summary
- add `PGVectorStore.search` to fetch top-matching chunks
- expose `RAGService.get_relevant_chunks` for accessing retrieved content

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c128f30e448328a77e4f4b9d5194be