### PR TITLE
feat: format docs for RAG

### DIFF
--- a/app/langchain/chains/qa_chain.py
+++ b/app/langchain/chains/qa_chain.py
@@ -7,6 +7,7 @@ from langchain_core.output_parsers import StrOutputParser
 # from langchain_openai import ChatOpenAI
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.vectorstores import VectorStore
+from app.utils import format_docs
 # load_dotenv(find_dotenv())
 
 def build_qa_chain(vectorstore: VectorStore, llm: BaseLanguageModel, *, k: int = 4):
@@ -33,7 +34,7 @@ Answer in Korean.
     )
 
     chain = (
-        {"context": retriever, "question": RunnablePassthrough()}
+        {"context": retriever | format_docs, "question": RunnablePassthrough()}
         | prompt
         | llm
         | StrOutputParser()

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,2 @@
+def format_docs(docs):
+    return "\n\n".join(doc.page_content for doc in docs)

--- a/basic_RAG.py
+++ b/basic_RAG.py
@@ -6,6 +6,8 @@ from langchain_core.runnables import RunnablePassthrough
 from langchain_core.prompts import PromptTemplate
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 from dotenv import load_dotenv
+from app.utils import format_docs
+
 load_dotenv(override=True)
 
 # 단계 1: 문서 로드(Load Documents)
@@ -49,7 +51,7 @@ llm = ChatOpenAI(model_name="gpt-4o", temperature=0)
 
 # 단계 8: 체인(Chain) 생성
 chain = (
-    {"context": retriever, "question": RunnablePassthrough()}
+    {"context": retriever | format_docs, "question": RunnablePassthrough()}
     | prompt
     | llm
     | StrOutputParser()


### PR DESCRIPTION
## Summary
- add `format_docs` utility to join document content
- pass formatted retriever context to QA chain and basic example

## Testing
- `python -m py_compile app/langchain/chains/qa_chain.py basic_RAG.py app/utils.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c13a74364883288c845a0c6246c3e5