### PR TITLE
Rename score to distance in vector search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,8 @@ curl -X POST http://localhost:5000/api/v1/rag/query \
 {
   "answer": "퇴직금은 ...",
   "sources": [
-    {"document_id":123,"chunk_id":456,"score":0.82,"snippet":"..."},
-    {"document_id":124,"chunk_id":400,"score":0.79,"snippet":"..."}
+    {"document_id":123,"chunk_id":456,"distance":0.82,"snippet":"..."},
+    {"document_id":124,"chunk_id":400,"distance":0.79,"snippet":"..."}
   ],
   "latency_ms": 842
 }
@@ -253,7 +253,7 @@ python -m app.services.rag.evaluator --dataset path/to/queries.jsonl --top_k 8
 // AnswerResponse
 {
   answer: string;
-  sources: {document_id:number; chunk_id:number; score:number; snippet:string;}[];
+  sources: {document_id:number; chunk_id:number; distance:number; snippet:string;}[];
   latency_ms?: number;
 }
 ```

--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -94,13 +94,13 @@ def search_chunks_by_vector(
     stmt = (
         select(
             models.Chunk,
-            models.Embedding.vector.cosine_distance(query_vector).label("score"),
+            models.Embedding.vector.cosine_distance(query_vector).label("distance"),
         )
         .join(models.Embedding, models.Chunk.id == models.Embedding.chunk_id)
         .order_by(models.Embedding.vector.cosine_distance(query_vector))
         .limit(top_k)
     )
     return [
-        (chunk, float(score))
-        for chunk, score in db.execute(stmt).all()
+        (chunk, float(distance))
+        for chunk, distance in db.execute(stmt).all()
     ]

--- a/app/services/rag/vectorstore.py
+++ b/app/services/rag/vectorstore.py
@@ -23,12 +23,12 @@ class PGVectorRetriever(BaseRetriever):
             Document(
                 page_content=chunk.content,
                 metadata={
-                    "score": score,
+                    "distance": distance,
                     "chunk_id": chunk.id,
                     "document_id": chunk.document_id,
                 },
             )
-            for chunk, score in results
+            for chunk, distance in results
         ]
 
     async def _aget_relevant_documents(self, query: str, run_manager=None) -> List[Document]:
@@ -54,10 +54,10 @@ class PGVectorStore:
             Document(
                 page_content=chunk.content,
                 metadata={
-                    "score": score,
+                    "distance": distance,
                     "chunk_id": chunk.id,
                     "document_id": chunk.document_id,
                 },
             )
-            for chunk, score in results
+            for chunk, distance in results
         ]


### PR DESCRIPTION
## Summary
- Rename `score` to `distance` in `search_chunks_by_vector` for clearer semantics
- Propagate `distance` metadata through `PGVectorRetriever` and `PGVectorStore`
- Update README examples and types to reflect `distance` field

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c13ffd81308328abb8c7e452658b02