### PR TITLE
refactor: handle question input only

### DIFF
--- a/app/langchain/chains/qa_chain.py
+++ b/app/langchain/chains/qa_chain.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 # from dotenv import load_dotenv, find_dotenv
+from operator import itemgetter
+
 from langchain_core.prompts import PromptTemplate
-from langchain_core.runnables import RunnablePassthrough
 from langchain_core.output_parsers import StrOutputParser
 # from langchain_openai import ChatOpenAI
 from langchain_core.language_models import BaseLanguageModel
@@ -12,11 +13,18 @@ from app.utils import format_docs
 
 def build_qa_chain(vectorstore: VectorStore, llm: BaseLanguageModel, *, k: int = 4):
     """벡터스토어 기반 QA 체인을 생성한다.
+
+    생성된 체인은 ``invoke({"question": "..."})``와 같이 호출한다.
+
     Args:
         vectorstore: ``as_retriever`` 메서드를 제공하는 벡터스토어 인스턴스.
 
     Returns:
-        LangChain Runnable. ``invoke({"question": "..."})`` 형식으로 호출한다.
+        LangChain Runnable.
+
+    예시:
+        >>> chain = build_qa_chain(vectorstore, llm)
+        >>> chain.invoke({"question": "LangChain은 무엇인가요?"})
     """
     retriever = vectorstore.as_retriever(search_kwargs={"k": k})
     prompt = PromptTemplate.from_template(
@@ -34,7 +42,10 @@ Answer in Korean.
     )
 
     chain = (
-        {"context": retriever | format_docs, "question": RunnablePassthrough()}
+        {
+            "context": itemgetter("question") | retriever | format_docs,
+            "question": itemgetter("question"),
+        }
         | prompt
         | llm
         | StrOutputParser()


### PR DESCRIPTION
## Summary
- use `itemgetter` to fetch the question for both retriever and prompt
- clarify docstring and example: call via `invoke({"question": "..."})`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c141a7fadc8328994c649d0024668e