### PR TITLE
docs: 명시된 파일 형식과 확장 방법 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,22 @@ ON chunk USING gin (content gin_trgm_ops);
 
 ## 사용법
 
+### 지원 파일 형식 및 제한
+
+현재 업로드/인제스트 파이프라인은 **PDF(`.pdf`)**만 지원합니다. 스캔한 이미지 기반 PDF는 OCR을 거치지 않으면 텍스트가 추출되지 않아 인제스트가 실패할 수 있습니다. PDF 이외의 확장자는 업로드 시 400 에러가 반환됩니다.
+
+추가 확장자를 지원하려면 다음 단계를 수행합니다(예: `.docx` 지원):
+
+1. `app/services/ingestion/loader.py`에 새로운 확장자 분기와 변환 로직을 추가합니다.
+2. `app/services/ingestion/preprocess/`에 해당 포맷을 PDF로 변환하거나 직접 파싱하는 모듈을 작성합니다(예: `convert_docx.py`).
+3. `app/services/ingestion/parser.py`에서 확장자별 전처리 모듈을 호출해 기존 파이프라인으로 넘겨줍니다.
+
+```python
+# loader.py 예시
+elif ext == ".docx":
+    input_pdf = convert_docx_to_pdf(upload_path)
+```
+
 ### 파일 업로드 및 인제스트
 
 ```bash

--- a/app/services/ingestion/ingestion.txt
+++ b/app/services/ingestion/ingestion.txt
@@ -10,6 +10,20 @@ app/services/ingestion/
 ├─ loader.py                  # 업로드→정규화 진입점
 └─ __init__.py
 
+지원 파일 형식: 현재 파이프라인은 **PDF(`.pdf`)**만 처리합니다. 스캔 PDF는 OCR 결과에 따라 실패할 수 있으며, 다른 확장자는 업로드 단계에서 거부됩니다.
+
+추가 확장자 지원 방법(예: `.docx`):
+
+1. `loader.py`에 확장자 분기와 변환 로직을 추가합니다.
+2. `preprocess/` 디렉터리에 해당 포맷을 PDF로 변환하거나 직접 파싱하는 모듈을 작성합니다(예: `convert_docx.py`).
+3. `parser.py`에서 새 모듈을 호출해 기존 파이프라인으로 넘겨줍니다.
+
+```python
+# loader.py 예시
+elif ext == ".docx":
+    input_pdf = convert_docx_to_pdf(path)
+```
+
 각 단계는 입력 → 출력만 명확히 한다
 
 1. loader.py


### PR DESCRIPTION
## Summary
- README에 현재 지원 파일 형식(PDF)과 확장 방법 예시 추가
- ingestion 파이프라인 문서에 파일 형식 제한 및 확장 절차 명시

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c15de821d4832886833d597fa7cb06